### PR TITLE
Use experimental node-java with varargs support.

### DIFF
--- a/lib/vertex-wrapper.js
+++ b/lib/vertex-wrapper.js
@@ -29,7 +29,7 @@ VertexWrapper.prototype.addEdge = function (label, inVertex, properties, callbac
 };
 
 VertexWrapper.prototype.setProperty = function (key, value, callback) {
-  return Q.nbind(this.el.singleProperty, this.el)(key, value, this.gremlin.emptyArrayList).nodeify(callback);
+  return Q.nbind(this.el.singleProperty, this.el)(key, value).nodeify(callback);
 };
 
 VertexWrapper.simplifyVertexProperties = function (obj) {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "debug": "^2.1.1",
     "glob": "~4.3.5",
-    "java": ">=0.4.6",
+    "java": "git://github.com/RedSeal-co/node-java.git#varargs.r3",
     "json-stable-stringify": "^1.0.0",
     "lodash": "^3.2.0",
     "q": "^1.1.2"


### PR DESCRIPTION
@mhfrantz Feel free to treat this as an RFC and hold off on merging if you are so inclined. We will probably be able to merge the varags.r3 branch (or rebase thereof) into node-java sometime next week, and could wait to update gremlin-v3 until then.

This changes the package.json to install java from an experimental branch of node-java,
which has support for varargs. This new feature is not fully backwards compatible,
but it turns out the impact on gremlin-v3 is isolated to one change in vertex-wrapper.js.

[Finishes #90828154]
