### PR TITLE
Use experimental node-java with varargs support

### DIFF
--- a/lib/graph-wrapper.js
+++ b/lib/graph-wrapper.js
@@ -275,7 +275,7 @@ GraphWrapper.prototype.getVertex = function (id, callback) {
   var gremlin = this.gremlin;
   var txn = this._getTransaction();
 
-  return Q.nbind(txn.vertexIterator, txn)([id])
+  return Q.nbind(txn.vertexIterator, txn)(id)
     .then(function (vertexIterator) {
       return new Q(vertexIterator.hasNextSync() ? gremlin.wrapVertex(vertexIterator.nextSync()) : null);
     })
@@ -314,7 +314,7 @@ GraphWrapper.prototype.getEdge = function (id, callback) {
   var gremlin = this.gremlin;
   var txn = this._getTransaction();
 
-  return Q.nbind(txn.edgeIterator, txn)([id])
+  return Q.nbind(txn.edgeIterator, txn)(id)
     .then(function (edgeIterator) {
       if (edgeIterator.hasNextSync()) {
         return gremlin.wrapEdge(edgeIterator.nextSync());
@@ -401,7 +401,7 @@ function graphTraversalWrap(op) {
     dlog('graphTraversalWrap(%s)', op, args);
     var txn = this._getTransaction();
     // We use this with variadic Java calls, so pass the args as a single array.
-    return this.gremlin.wrapTraversal(txn[op + 'Sync'](args));
+    return this.gremlin.wrapTraversal(txn[op + 'Sync'].apply(txn, args));
   };
 }
 

--- a/lib/gremlin.js
+++ b/lib/gremlin.js
@@ -19,8 +19,8 @@ var java = require('java');
 
 var Gremlin = module.exports = function (opts) {
 
-  if (opts === java) {
-    // We assume that java has already been configured by the application.
+  if (opts && opts.java === java) {
+    // In this case we assume that java has already been configured by the application.
     // The application therefore assumes responsibility for proper configuration of classpath
     // and other java options.
     // Gremlin-v3 is unable to use the asyncOptions feature of node-java, so the defacto standard

--- a/lib/gremlin.js
+++ b/lib/gremlin.js
@@ -15,33 +15,45 @@ var EdgeWrapper = require('./edge-wrapper');
 var IteratorWrapper = require('./iterator-wrapper');
 var PathWrapper = require('./path-wrapper');
 
+var java = require('java');
+
 var Gremlin = module.exports = function (opts) {
-  opts = opts || {};
-  opts.options = opts.options || [];
-  opts.classpath = opts.classpath || [];
 
-  // Add our own JAR first, so that we can provide alternate implementation of Gremlin classes for debugging.
-  opts.classpath.push(path.join(__dirname, '..', 'target', 'gremlin-node-*.jar'));
-  // Add the rest of the JAR's from the Maven package.
-  opts.classpath.push(path.join(__dirname, '..', 'target', '*', '**', '*.jar'));
-
-  // initialize java
-  var java = this.java = require('java');
-
-  // add options
-  java.options.push('-Djava.awt.headless=true');
-  for (var i = 0; i < opts.options.length; i++) {
-    java.options.push(opts.options[i]);
+  if (opts === java) {
+    // We assume that java has already been configured by the application.
+    // The application therefore assumes responsibility for proper configuration of classpath
+    // and other java options.
+    // Gremlin-v3 is unable to use the asyncOptions feature of node-java, so the defacto standard
+    // configuration of sync and async method variants must be used, i.e. syncSuffix='Sync' and
+    // asyncSuffix=''.
   }
+  else {
+    opts = opts || {};
+    opts.options = opts.options || [];
+    opts.classpath = opts.classpath || [];
 
-  // add jar files
-  for (var i = 0; i < opts.classpath.length; i++) {
-    var pattern = opts.classpath[i];
-    var filenames = glob.sync(pattern);
-    for (var j = 0; j < filenames.length; j++) {
-      java.classpath.push(filenames[j]);
+    // Add our own JAR first, so that we can provide alternate implementation of Gremlin classes for debugging.
+    opts.classpath.push(path.join(__dirname, '..', 'target', 'gremlin-node-*.jar'));
+    // Add the rest of the JAR's from the Maven package.
+    opts.classpath.push(path.join(__dirname, '..', 'target', '*', '**', '*.jar'));
+
+    // add options
+    java.options.push('-Djava.awt.headless=true');
+    for (var i = 0; i < opts.options.length; i++) {
+      java.options.push(opts.options[i]);
+    }
+
+    // add jar files
+    for (var i = 0; i < opts.classpath.length; i++) {
+      var pattern = opts.classpath[i];
+      var filenames = glob.sync(pattern);
+      for (var j = 0; j < filenames.length; j++) {
+        java.classpath.push(filenames[j]);
+      }
     }
   }
+
+  this.java = java;
 
   var MIN_VALUE = 0;
   var MAX_VALUE = java.newInstanceSync('java.lang.Long', 2147483647);

--- a/lib/vertex-wrapper.js
+++ b/lib/vertex-wrapper.js
@@ -29,7 +29,7 @@ VertexWrapper.prototype.addEdge = function (label, inVertex, properties, callbac
 };
 
 VertexWrapper.prototype.setProperty = function (key, value, callback) {
-  return Q.nbind(this.el.singleProperty, this.el)(key, value, this.gremlin.emptyArrayList).nodeify(callback);
+  return Q.nbind(this.el.singleProperty, this.el)(key, value).nodeify(callback);
 };
 
 VertexWrapper.simplifyVertexProperties = function (obj) {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "debug": "^2.1.1",
     "glob": "~4.3.5",
-    "java": ">=0.4.6",
+    "java": "git://github.com/RedSeal-co/node-java.git#varargs.r3",
     "json-stable-stringify": "^1.0.0",
     "lodash": "^3.2.0",
     "q": "^1.1.2"

--- a/test/test-traversal-wrapper.js
+++ b/test/test-traversal-wrapper.js
@@ -794,7 +794,7 @@ suite('traversal-wrapper', function () {
   });
 
   test('inject("daniel")', function (done) {
-    g.V().has('name', 'josh').out().values('name').inject(['daniel']).toArray(function (err, actual) {
+    g.V().has('name', 'josh').out().values('name').inject('daniel').toArray(function (err, actual) {
       var expected = ['daniel', 'ripple', 'lop'];
       assert.deepEqual(actual, expected);
       done();


### PR DESCRIPTION
This feature branch does two things:
1) Switch to the node-java branch with varargs support, including a few necessary changes due to the fact that the varags support is not completely backwards compatible.
2) Changes Gremlin initialization to make it possible to configure node-java outside of Gremlin.
