### PR TITLE
Improve Gremlin handling of java configuration.

### DIFF
--- a/lib/gremlin.js
+++ b/lib/gremlin.js
@@ -6,6 +6,7 @@ var fs = require('fs');
 var glob = require('glob');
 var path = require('path');
 var Q = require('q');
+var dlog = require('debug')('gremlin-v3');
 
 var GraphWrapper = require('./graph-wrapper');
 var QueryWrapper = require('./query-wrapper');
@@ -19,15 +20,24 @@ var java = require('java');
 
 var Gremlin = module.exports = function (opts) {
 
-  if (opts && opts.java === java) {
+  // java.onJvmCreated is a property that holds a function that is executed only once when
+  // the JVM has been created. After creation, the property is made inaccessible.
+  var jvmCreated = !_.isFunction(java.onJvmCreated);
+
+  if (jvmCreated) {
+    dlog('Gremlin initialized after JVM already created. Java:', java);
+  }
+  else if (opts && opts.java) {
     // In this case we assume that java has already been configured by the application.
     // The application therefore assumes responsibility for proper configuration of classpath
     // and other java options.
     // Gremlin-v3 is unable to use the asyncOptions feature of node-java, so the defacto standard
     // configuration of sync and async method variants must be used, i.e. syncSuffix='Sync' and
     // asyncSuffix=''.
+    dlog('Gremlin initialized with already configured java:', java);
   }
   else {
+    dlog('Gremlin initialized with unconfigured java. Opts:', opts);
     opts = opts || {};
     opts.options = opts.options || [];
     opts.classpath = opts.classpath || [];
@@ -35,7 +45,7 @@ var Gremlin = module.exports = function (opts) {
     // Add our own JAR first, so that we can provide alternate implementation of Gremlin classes for debugging.
     opts.classpath.push(path.join(__dirname, '..', 'target', 'gremlin-node-*.jar'));
     // Add the rest of the JAR's from the Maven package.
-    opts.classpath.push(path.join(__dirname, '..', 'target', '*', '**', '*.jar'));
+    opts.classpath.push(path.join(__dirname, '..', 'target', 'dependency', '**', '*.jar'));
 
     // add options
     java.options.push('-Djava.awt.headless=true');
@@ -44,15 +54,18 @@ var Gremlin = module.exports = function (opts) {
     }
 
     // add jar files
-    for (var i = 0; i < opts.classpath.length; i++) {
-      var pattern = opts.classpath[i];
+    _.forEach(opts.classpath, function(pattern) {
       var filenames = glob.sync(pattern);
-      for (var j = 0; j < filenames.length; j++) {
-        java.classpath.push(filenames[j]);
-      }
-    }
+      _.forEach(filenames, function(jarPath) {
+        // We prevent duplicates here, since it is easy to do.
+        // But duplicates should only happen if class path patterns are somehow redundant.
+        if (!_.includes(java.classpath, jarPath))
+          java.classpath.push(jarPath);
+      });
+    });
   }
 
+  dlog('Gremlin configured with classpath:', java.classpath);
   this.java = java;
 
   var MIN_VALUE = 0;


### PR DESCRIPTION
@mhfrantz The change to make it possible to configure java outside of Gremlin wasn't quite right. This should work correctly, and as a bonus, it detects the case where the JVM has already been created.
